### PR TITLE
[doc, data] feat: add dataset download instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,11 @@
 
 # 🔊 ECHO: Prune to Act, Trace to Learn with Selective Turn Memory in Agentic RL
 
+<p>
+  <a href="https://arxiv.org/abs/2606.31650"><img src="https://img.shields.io/badge/arXiv-2606.31650-b31b1b.svg" alt="arXiv"></a>
+  <a href="https://huggingface.co/datasets/b1Ack714/echo"><img src="https://img.shields.io/badge/%F0%9F%A4%97%20Dataset-Hugging%20Face-yellow" alt="Hugging Face Dataset"></a>
+</p>
+
 </div>
 
 **ECHO** is a selective turn-memory framework for traceable context reconstruction in

--- a/README.md
+++ b/README.md
@@ -124,8 +124,25 @@ pip install -e .
 ## 📦 Data Preparation
 
 ECHO is trained and evaluated on
-[BrowseComp-Plus](https://github.com/texttron/BrowseComp-Plus). Build the prompt
-parquet files with:
+[BrowseComp-Plus](https://github.com/texttron/BrowseComp-Plus).
+
+You can download the preprocessed ECHO data from
+[Hugging Face](https://huggingface.co/datasets/b1Ack714/echo):
+
+```bash
+huggingface-cli download b1Ack714/echo \
+  --repo-type dataset \
+  --local-dir /path/to/browsecomp-plus-processed
+```
+
+Then point the training scripts at that directory:
+
+```bash
+export DATA_DIR=/path/to/browsecomp-plus-processed
+```
+
+Alternatively, build the prompt parquet files from a local BrowseComp-Plus copy
+with:
 
 ```bash
 python3 examples/data_preprocess/bcp_paper_prompt.py


### PR DESCRIPTION
## Summary
- Add badges linking to the arXiv paper and Hugging Face dataset
- Add Hugging Face download instructions for the preprocessed ECHO dataset
- Document DATA_DIR setup for training scripts
- Keep local BrowseComp-Plus preprocessing as an alternative path

## Testing
- Not run locally (documentation-only change)