### PR TITLE
Fix last-token pooling under left padding in BCP dense retrieval server

### DIFF
--- a/examples/sglang_multiturn/browsecomp_retrieval_server.py
+++ b/examples/sglang_multiturn/browsecomp_retrieval_server.py
@@ -313,7 +313,13 @@ class DenseRetriever:
     # ------------------------------------------------------------------
     def _last_token_pool(self, last_hidden_states, attention_mask):
         import torch
-        # Qwen3-Embedding uses decoder architecture -> last token pooling
+        # Qwen3-Embedding uses decoder architecture -> last token pooling.
+        # The tokenizer is loaded with padding_side="left", so in a batch the last
+        # valid token sits at the final position; the sum-1 index is only correct
+        # for right padding. Handle both (same as the Qwen3-Embedding model card).
+        left_padding = (attention_mask[:, -1].sum() == attention_mask.shape[0])
+        if left_padding:
+            return last_hidden_states[:, -1]
         seq_lens = attention_mask.sum(dim=1) - 1
         batch_size = last_hidden_states.shape[0]
         return last_hidden_states[torch.arange(batch_size, device=last_hidden_states.device), seq_lens]
@@ -337,7 +343,10 @@ class DenseRetriever:
                 return_tensors="pt",
             ).to(device)
             with torch.no_grad():
-                hidden = self.model(**enc)  # wrapper returns last_hidden_state directly
+                out = self.model(**enc)
+            # The multi-GPU DataParallel wrapper returns the last_hidden_state tensor
+            # directly; the raw AutoModel (single-GPU path) returns a ModelOutput.
+            hidden = out.last_hidden_state if hasattr(out, "last_hidden_state") else out
             emb = self._last_token_pool(hidden, enc["attention_mask"])
             emb = F.normalize(emb, p=2, dim=1)
             all_embs.append(emb.cpu().float().numpy())


### PR DESCRIPTION
## Bug

`browsecomp_retrieval_server.py` loads the Qwen3-Embedding tokenizer with `padding_side="left"`, but `_last_token_pool` picks hidden states at index `attention_mask.sum(1) - 1`, which is only correct for **right** padding.

In batched document encoding (dense cache build, default `batch_size=4`), every sequence shorter than the batch max gets pooled at a wrong position — mid-sequence, or even a **pad position** when a document is shorter than half the batch max. Single-query search (batch of 1) is unaffected, which makes the bug easy to miss.

## Measured impact

- On real BrowseComp-Plus documents, batched vs per-item embeddings agree only at **cosine mean 0.37 / min 0.08** — most cached document vectors are effectively random.
- After applying this fix and rebuilding the dense cache (Qwen3-Embedding-8B, `max_doc_length=8192`):
  - gold hit@5 (830 BCP questions, question as query): **7.2% → 34.2%**
  - end-to-end zero-RL Qwen3-32B on the 830-question set (search-agent loop + LLM judge): **2.05% → 9.76%**, now in line with the official BrowseComp-Plus leaderboard scale (10.72% for Qwen3-32B + Qwen3-Embedding-8B).

This may also explain the very low pre-RL starting points discussed in #18.

## Changes

1. `_last_token_pool`: detect padding side from the attention mask and index accordingly (same logic as the Qwen3-Embedding model card / tevatron).
2. `_encode_bulk`: the single-GPU path passed a transformers `ModelOutput` where a tensor is expected (crash); the multi-GPU `DataParallel` wrapper returns the tensor directly, which is why multi-GPU cache builds did not crash.

**Note for users:** dense caches built with the previous pooling should be rebuilt after this fix.